### PR TITLE
Fix the deployment of Prometheus and Grafana

### DIFF
--- a/ansible/istio/add_serviceaccount_to_addon.yml
+++ b/ansible/istio/add_serviceaccount_to_addon.yml
@@ -1,0 +1,29 @@
+# Adds ServiceAccount to add-ons that need them and do not have them defined
+# This is done in order to avoid giving scc anyuid to the default ServiceAccount
+
+- set_fact:
+    add_on_file_path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
+
+- name: Determine whether a ServiceAccount is present in the file
+  command: grep 'serviceAccountName' {{ add_on_file_path }}
+  register: go
+  ignore_errors: true
+
+- name: Add ServiceAccount to {{ add_on_name }} add-on
+  replace:
+    path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
+    regexp: '^(\s*)containers:\s*$'
+    replace: '\1serviceAccountName: istio-{{ add_on_name }}-service-account\n\1containers:'
+    backup: yes
+  when: go.stdout_lines | length == 0
+
+- set_fact:
+    add_on_definition_path: /tmp/{{ add_on_name }}-service-account
+
+- name: Create ServiceAccount definition from template
+  template: src=addon_serviceaccount.yml.j2 dest=/tmp/{{ add_on_name }}-service-account
+
+- name: Apply ServiceAccount from template
+  command: oc create -f {{add_on_definition_path}}
+  ignore_errors: true
+

--- a/ansible/istio/addon_serviceaccount.yml.j2
+++ b/ansible/istio/addon_serviceaccount.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-{{ add_on_name }}-service-account

--- a/ansible/istio/change_scc.yml
+++ b/ansible/istio/change_scc.yml
@@ -1,9 +1,17 @@
 # Openshift by default does not allow containers running with UID 0. Enable containers running with UID 0 for Istio’s service accounts
 - name: Define SCC rules to enable containers running with UID zero for Istio service accounts
-  shell: oc adm policy add-scc-to-user anyuid -z {{item}}
+  command: oc adm policy add-scc-to-user anyuid -z {{item}}
   with_items:
     - istio-ingress-service-account
     - istio-egress-service-account
     - istio-pilot-service-account
     - istio-mixer-service-account
     - istio-ca-service-account
+
+- name: Define SCC rules to enable containers running with UID zero for Prometheus service accounts
+  command: oc adm policy add-scc-to-user anyuid -z istio-prometheus-service-account
+  when: "'prometheus' in istio.addon"
+
+- name: Define SCC rules to enable containers running with UID zero for Grafana service accounts
+  command: oc adm policy add-scc-to-user anyuid -z istio-grafana-service-account
+  when: "'grafana' in istio.addon"

--- a/ansible/istio/install_addons.yml
+++ b/ansible/istio/install_addons.yml
@@ -1,3 +1,11 @@
+- include_tasks: add_serviceaccount_to_addon.yml
+    add_on_name=prometheus
+  when: "'prometheus' in istio.addon"
+
+- include_tasks: add_serviceaccount_to_addon.yml
+    add_on_name=grafana
+  when: "'grafana' in istio.addon"
+
 - name: Install Addons
   shell: |
     oc create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml


### PR DESCRIPTION
Before applying this patch, Prometheus and Grafana did not work on
Openshift, due to permission issues. The solution implemented by the
patch is to add specific ServiceAccounts for Prometheus and Grafana
and patch the respective Kubernetes description files to use those SAs.

I will also apply this change to the Open PR #6 momentarily