### PR TITLE
Use with_items when adding ServiceAccounts to addons

### DIFF
--- a/ansible/istio/tasks/change_scc.yml
+++ b/ansible/istio/tasks/change_scc.yml
@@ -8,10 +8,6 @@
     - istio-mixer-service-account
     - istio-ca-service-account
 
-- name: Define SCC rules to enable containers running with UID zero for Prometheus service accounts
-  command: "{{ oc_path }} adm policy add-scc-to-user anyuid -z istio-prometheus-service-account"
-  when: "'prometheus' in istio.addon"
-
-- name: Define SCC rules to enable containers running with UID zero for Grafana service accounts
-  command: "{{ oc_path }} adm policy add-scc-to-user anyuid -z istio-grafana-service-account"
-  when: "'grafana' in istio.addon"
+- name: Define SCC rules to enable containers running with UID zero for Addon service accounts
+  command: "{{ oc_path }} adm policy add-scc-to-user anyuid -z istio-item-service-account"
+  with_items: "{{selected_addons_needing_sa}}"

--- a/ansible/istio/tasks/install_addons.yml
+++ b/ansible/istio/tasks/install_addons.yml
@@ -1,10 +1,6 @@
 - include_tasks: add_serviceaccount_to_addon.yml
-    add_on_name=prometheus
-  when: "'prometheus' in istio.addon"
-
-- include_tasks: add_serviceaccount_to_addon.yml
-    add_on_name=grafana
-  when: "'grafana' in istio.addon"
+    add_on_name="{{item}}"
+  with_items: "{{selected_addons_needing_sa}}"
 
 - name: Install Addons
   shell: |

--- a/ansible/istio/tasks/main.yml
+++ b/ansible/istio/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Determine addons that need ServiceAccounts
+  set_fact:
+    selected_addons_needing_sa: "{{ istio.addon | intersect(addons_needing_sa) }}"
+
+- debug:
+    var: selected_addons_needing_sa
+
 - include_role:
     name: minishift
   when: run_minishift_role

--- a/ansible/istio/vars/main.yml
+++ b/ansible/istio/vars/main.yml
@@ -1,3 +1,6 @@
 ---
 github_url: https://api.github.com/repos
 istio_repo: istio/istio
+addons_needing_sa:
+  - "grafana"
+  - "prometheus"


### PR DESCRIPTION
No longer need to hard-code 'prometheus' and 'grafana' inside the tasks.
We just add them to a configuration and make the tasks iterate using `with_items`