### PR TITLE
Eliminate errors that occur when installing Jaeger

### DIFF
--- a/README-ANSIBLE.md
+++ b/README-ANSIBLE.md
@@ -148,3 +148,12 @@ ansible-playbook ansible/main.yml -t istio -e '{"cluster_url": "host:ip"}'
 ```bash
 ansible-playbook ansible/main.yml -t istio -e '{"istio": {"release_tag_name": "0.4.0", "auth": true, "jaeger": true, "delete_resources": true}}'
 ```
+
+- User already has the oc binary pointing to a running Minishift cluster and wants to customize the Istio addons
+```bash
+ansible-playbook ansible/main.yml -t istio -e '{"istio": {"delete_resources": true, "addons": ["grafana", "prometheus"]}}'
+```
+
+The list of available addons can be found at `ansible/istio/vars.main.yml` under the name `istio_all_addons`.
+Jaeger is not installed using the `addons` property, but can be installed by enabling `"jaeger": true` like in one of the previous examples.
+It should be noted that when Jaeger is enabled, Zipkin is disabled whether or not it's been selected in the addons section.

--- a/README-ANSIBLE.md
+++ b/README-ANSIBLE.md
@@ -129,27 +129,27 @@ of Istio need to be reinstalled, then it is advisable to delete the `istio-syste
 
 Following are the simplest commands one could execute to play with the demo for some typical use cases
 
-- User does not have Minishift installed locally, nor has an `oc` binary pointing to a remote cluster :
+- User does not have Minishift installed locally and want's to install it and use it to install istio :
 ```bash
 ansible-playbook ansible/main.yml -t istio -e '{"run_minishift_role": true}'
 ```
 
-- User already has the oc binary pointing to a running Minishift cluster
+- User already has Minishift installed and wants to use it to install Istio
 ```bash
 ansible-playbook ansible/main.yml -t istio
 ```
 
-- User already has the oc binary pointing to a remote Openshift cluster
+- User has a non-local Openshift cluster and wants to it to install Istio
 ```bash
 ansible-playbook ansible/main.yml -t istio -e '{"cluster_url": "host:ip"}'
 ```
 
-- User already has the oc binary pointing to a running Minishift cluster and wants to install Istio with settings other than the default
+- User wants to install Istio on Minishift with settings other than the default
 ```bash
 ansible-playbook ansible/main.yml -t istio -e '{"istio": {"release_tag_name": "0.4.0", "auth": true, "jaeger": true, "delete_resources": true}}'
 ```
 
-- User already has the oc binary pointing to a running Minishift cluster and wants to customize the Istio addons
+- User wants to install Istio on Minishift and wants to customize the Istio addons
 ```bash
 ansible-playbook ansible/main.yml -t istio -e '{"istio": {"delete_resources": true, "addons": ["grafana", "prometheus"]}}'
 ```

--- a/ansible/istio/tasks/install_addons.yml
+++ b/ansible/istio/tasks/install_addons.yml
@@ -6,12 +6,10 @@
   shell: |
     {{ oc_path }} create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml
     {{ oc_path }} expose svc {{ item }}
-  with_items: "{{ istio.addon }}"
+  with_items: "{{ istio.addon | difference(disabled_addons) }}"
   when: is_istioaddon_iterable
 
 - name: Install Jaeger
   shell: |
     {{ oc_path }} process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/all-in-one/jaeger-all-in-one-template.yml | {{ oc_path }} create -f -
-    {{ oc_path }} expose svc jaeger
   when: istio.jaeger
-  ignore_errors: true # can fail because Zipkin might already be installed in the addons

--- a/ansible/istio/tasks/main.yml
+++ b/ansible/istio/tasks/main.yml
@@ -1,24 +1,20 @@
 ---
 
+- include_tasks: set_implicitly_disabled_addons.yml
+
 - name: Is istio.addon be iterable
   set_fact:
     is_istioaddon_iterable: "{{ istio.addon is defined and istio.addon is iterable }}"
 
-- debug:
-    var: is_istioaddon_iterable
-
 - name: Determine addons that need ServiceAccounts
   set_fact:
-    selected_addons_needing_sa: "{{ istio.addon | intersect(addons_needing_sa) }}"
+    selected_addons_needing_sa: "{{ istio.addon | intersect(addons_needing_sa) | difference(disabled_addons) }}"
   when: is_istioaddon_iterable == true
 
 - name: Set selected_addons_needing_sa to empty array
   set_fact:
     selected_addons_needing_sa: "[]"
   when: is_istioaddon_iterable == false
-
-- debug:
-    var: selected_addons_needing_sa
 
 - include_role:
     name: minishift

--- a/ansible/istio/tasks/set_implicitly_disabled_addons.yml
+++ b/ansible/istio/tasks/set_implicitly_disabled_addons.yml
@@ -1,0 +1,12 @@
+# This file will result in the disabled_plugins variables being set
+# The functionality is needed because some features are mutually exclusive
+# (for example when Jaeger is enabled, Zipkin needs to be disabled)
+
+- name: Set default / empty disabled addons
+  set_fact:
+    disabled_addons: "[]"
+
+- name: Set zipkin disabled addon
+  set_fact:
+    disabled_addons: "{{ disabled_addons }} + [ 'zipkin' ]"
+  when: istio.jaeger == true


### PR DESCRIPTION
One error had to do with Zipkin being installed along Jaeger and the
other had to do with exposing a non-existing service