### PR TITLE
Simplify ServiceAccount creation for add-ons

### DIFF
--- a/ansible/istio/tasks/add_serviceaccount_to_addon.yml
+++ b/ansible/istio/tasks/add_serviceaccount_to_addon.yml
@@ -20,11 +20,8 @@
 - set_fact:
     add_on_definition_path: /tmp/{{ add_on_name }}-service-account
 
-- name: Create ServiceAccount definition from template for {{ add_on_name }}
-  template: src=addon_serviceaccount.yml.j2 dest=/tmp/{{ add_on_name }}-service-account
-
 - name: Apply ServiceAccount from template for {{ add_on_name }}
-  command: "{{ cmd_path }}  create -f {{add_on_definition_path}} -n istio-system"
+  command: "{{ cmd_path }} create serviceaccount istio-{{ add_on_name }}-service-account -n istio-system"
   ignore_errors: true
 
 - name: Define SCC rules to enable containers running with UID zero for Addon service accounts for {{ add_on_name }}

--- a/ansible/istio/tasks/addon_serviceaccount.yml.j2
+++ b/ansible/istio/tasks/addon_serviceaccount.yml.j2
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: istio-{{ add_on_name }}-service-account


### PR DESCRIPTION
We now leverage `oc create serviceaccount` instead of creating a temporary
file