### PR TITLE
Correctly handle the case where addons are left empty

### DIFF
--- a/ansible/istio/tasks/install_addons.yml
+++ b/ansible/istio/tasks/install_addons.yml
@@ -3,12 +3,7 @@
   with_items: "{{ selected_addons_needing_sa }}"
   when: cluster_flavour == 'ocp'
 
-- name: Install Addons
-  shell: |
-    {{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml
-    {{ cmd_path }} expose svc {{ item }} -n istio-system
-  with_items: "{{ istio.addon | difference(disabled_addons) }}"
-  ignore_errors: true
+- include_tasks: install_istio_addons.yml
   when: is_istioaddon_iterable
 
 - name: Install Jaeger on Openshift

--- a/ansible/istio/tasks/install_istio_addons.yml
+++ b/ansible/istio/tasks/install_istio_addons.yml
@@ -1,0 +1,6 @@
+- name: Install addon {{ add_on_name }} from Istio definition file
+  shell: |
+    {{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml
+    {{ cmd_path }} expose svc {{ item }} -n istio-system
+  with_items: "{{ istio.addon | difference(disabled_addons) }}"
+  ignore_errors: true


### PR DESCRIPTION
The error was occurring because when `when` and `with_items` are both
present, `when` is always evaluated for each item in the loop and
not before as was supposed to be the case

Fixes: #32